### PR TITLE
Puertas de pods sin energia

### DIFF
--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -65,6 +65,16 @@
 /obj/random/torchcloset,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fourthdeck/forestarboard)
+"ap" = (
+/obj/machinery/shield_diffuser,
+/obj/machinery/door/airlock/external/escapepod{
+	frequency = 1380;
+	id_tag = "escape_pod1_berth_hatch";
+	locked = 1;
+	name = "Escape Pod One"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/pod_airlock/pod1)
 "aq" = (
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/fourthdeck/starboard)
@@ -331,6 +341,17 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/forestarboard)
+"aT" = (
+/obj/machinery/door/airlock/external/escapepod{
+	frequency = 1380;
+	icon_state = "closed";
+	id_tag = "escape_pod2_berth_hatch";
+	locked = 1;
+	name = "Escape Pod Two"
+	},
+/obj/machinery/shield_diffuser,
+/turf/simulated/floor/plating,
+/area/shuttle/pod_airlock/pod2)
 "aU" = (
 /obj/item/device/tape/random,
 /obj/random/trash,
@@ -396,6 +417,17 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/safe_room/fourthdeck)
+"bd" = (
+/obj/machinery/door/airlock/external/escapepod{
+	frequency = 1380;
+	icon_state = "closed";
+	id_tag = "escape_pod3_berth_hatch";
+	locked = 1;
+	name = "Escape Pod Three"
+	},
+/obj/machinery/shield_diffuser,
+/turf/simulated/floor/plating,
+/area/shuttle/pod_airlock/pod3)
 "be" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4;
@@ -674,6 +706,17 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/maintenance/aux_med)
+"bH" = (
+/obj/machinery/door/airlock/external/escapepod{
+	frequency = 1380;
+	icon_state = "closed";
+	id_tag = "escape_pod4_berth_hatch";
+	locked = 1;
+	name = "Escape Pod Four"
+	},
+/obj/machinery/shield_diffuser,
+/turf/simulated/floor/plating,
+/area/shuttle/pod_airlock/pod4)
 "bI" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -1261,17 +1304,6 @@
 /obj/random/hostile/maint,
 /turf/simulated/floor/tiled/white,
 /area/maintenance/aux_med)
-"dd" = (
-/obj/machinery/door/airlock/external/escapepod{
-	frequency = 1380;
-	icon_state = "closed";
-	id_tag = "escape_pod2_berth_hatch";
-	locked = 1;
-	name = "Escape Pod Two"
-	},
-/obj/machinery/shield_diffuser,
-/turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
 "de" = (
 /obj/machinery/optable,
 /obj/item/weapon/tank/anesthetic,
@@ -4062,15 +4094,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/hangar/top)
-"kp" = (
-/obj/effect/floor_decal/corner/green{
-	dir = 9
-	},
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/fourthdeck/aft)
 "kq" = (
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -5497,6 +5520,19 @@
 	},
 /turf/simulated/floor/shuttle_ceiling/torch/air,
 /area/quartermaster/hangar/top)
+"oV" = (
+/obj/effect/floor_decal/corner/white{
+	icon_state = "corner_white";
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 8
+	},
+/obj/machinery/newscaster{
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/fourthdeck/aft)
 "oW" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -8893,6 +8929,27 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
+"zb" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "shutter0";
+	id_tag = "hangar_checkpoint_shutters";
+	name = "Hangar Deck Checkpoint Shutters";
+	opacity = 0
+	},
+/obj/effect/wallframe_spawn/reinforced,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/security/hangcheck)
 "ze" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -10068,6 +10125,15 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/lounge)
+"EX" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 9
+	},
+/obj/machinery/newscaster{
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/fourthdeck/aft)
 "EZ" = (
 /obj/item/device/radio/intercom/entertainment{
 	dir = 8;
@@ -10463,17 +10529,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/fourthdeck/aft)
-"Gv" = (
-/obj/machinery/door/airlock/external/escapepod{
-	frequency = 1380;
-	icon_state = "closed";
-	id_tag = "escape_pod4_berth_hatch";
-	locked = 1;
-	name = "Escape Pod Four"
-	},
-/obj/machinery/shield_diffuser,
-/turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
 "Gw" = (
 /obj/structure/bed/chair/shuttle{
 	tag = "icon-shuttle_chair_preview (NORTH)";
@@ -10615,16 +10670,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark/monotile,
-/area/hallway/primary/fourthdeck/aft)
-"Hk" = (
-/obj/effect/floor_decal/corner/brown/half{
-	icon_state = "bordercolorhalf";
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fourthdeck/aft)
 "Hm" = (
 /obj/structure/cable{
@@ -14987,19 +15032,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/fourthdeck/aft)
-"Ug" = (
-/obj/effect/floor_decal/corner/white{
-	icon_state = "corner_white";
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/red{
-	dir = 8
-	},
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/fourthdeck/aft)
 "Uh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -15936,6 +15968,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
+"WQ" = (
+/obj/effect/floor_decal/corner/brown/half{
+	icon_state = "bordercolorhalf";
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/fourthdeck/aft)
 "WR" = (
 /obj/effect/floor_decal/corner/mauve/half{
 	icon_state = "bordercolorhalf";
@@ -16573,16 +16615,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/forestarboard)
-"Yw" = (
-/obj/machinery/shield_diffuser,
-/obj/machinery/door/airlock/external/escapepod{
-	frequency = 1380;
-	id_tag = "escape_pod1_berth_hatch";
-	locked = 1;
-	name = "Escape Pod One"
-	},
-/turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
 "Yx" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -17004,17 +17036,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/pathfinder)
-"ZA" = (
-/obj/machinery/door/airlock/external/escapepod{
-	frequency = 1380;
-	icon_state = "closed";
-	id_tag = "escape_pod3_berth_hatch";
-	locked = 1;
-	name = "Escape Pod Three"
-	},
-/obj/machinery/shield_diffuser,
-/turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
 "ZE" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -17144,27 +17165,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/aft)
-"ZT" = (
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 4;
-	icon_state = "shutter0";
-	id_tag = "hangar_checkpoint_shutters";
-	name = "Hangar Deck Checkpoint Shutters";
-	opacity = 0
-	},
-/obj/effect/wallframe_spawn/reinforced,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/security/hangcheck)
 "ZU" = (
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -32470,7 +32470,7 @@ sG
 NP
 Rm
 OX
-ZT
+zb
 NN
 OX
 OX
@@ -39131,7 +39131,7 @@ mN
 nW
 pj
 Xn
-Hk
+WQ
 lM
 WS
 vZ
@@ -41140,7 +41140,7 @@ wa
 Yj
 Yj
 wa
-Yw
+ap
 wa
 Yj
 Yj
@@ -41164,7 +41164,7 @@ wa
 Yj
 Yj
 wa
-ZA
+bd
 wa
 Yj
 Yj
@@ -41347,7 +41347,7 @@ LU
 ag
 ag
 ZP
-kp
+EX
 kD
 mQ
 ag
@@ -41370,7 +41370,7 @@ Ud
 KU
 uj
 uj
-Ug
+oV
 sc
 Jx
 eI
@@ -41746,7 +41746,7 @@ wa
 Yj
 Yj
 wa
-dd
+aT
 wa
 Yj
 Yj
@@ -41770,7 +41770,7 @@ wa
 Yj
 Yj
 wa
-Gv
+bH
 wa
 Yj
 Yj

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -31215,7 +31215,7 @@ gH
 Up
 ip
 fU
-JX
+qw
 mb
 mb
 Xe
@@ -31417,7 +31417,7 @@ WC
 fn
 iq
 fU
-JX
+qw
 OY
 mb
 Tg

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -347,6 +347,17 @@
 /obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/auxsolarstarboard)
+"aF" = (
+/obj/machinery/door/airlock/external/escapepod{
+	frequency = 1380;
+	icon_state = "closed";
+	id_tag = "escape_pod6_berth_hatch";
+	locked = 1;
+	name = "Escape Pod Six"
+	},
+/obj/machinery/shield_diffuser,
+/turf/simulated/floor/tiled/steel_ridged,
+/area/shuttle/pod_airlock/pod5)
 "aG" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/blast/regular{
@@ -752,6 +763,15 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/engineering/engine_room)
+"bq" = (
+/obj/machinery/shield_diffuser,
+/obj/machinery/door/airlock/external/escapepod{
+	id_tag = "escape_pod5_berth_hatch";
+	locked = 1;
+	name = "Escape Pod Five"
+	},
+/turf/simulated/floor/tiled/steel_ridged,
+/area/shuttle/pod_airlock/pod6)
 "br" = (
 /obj/machinery/light{
 	dir = 4
@@ -4967,17 +4987,6 @@
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/seconddeck/forestarboard)
-"jQ" = (
-/obj/machinery/door/airlock/external/escapepod{
-	frequency = 1380;
-	icon_state = "closed";
-	id_tag = "escape_pod6_berth_hatch";
-	locked = 1;
-	name = "Escape Pod Six"
-	},
-/obj/machinery/shield_diffuser,
-/turf/simulated/floor/tiled/steel_ridged,
 /area/maintenance/seconddeck/forestarboard)
 "jR" = (
 /obj/machinery/light{
@@ -10709,15 +10718,6 @@
 /obj/effect/floor_decal/corner/yellow,
 /turf/simulated/floor/tiled,
 /area/engineering/locker_room)
-"uL" = (
-/obj/machinery/shield_diffuser,
-/obj/machinery/door/airlock/external/escapepod{
-	id_tag = "escape_pod5_berth_hatch";
-	locked = 1;
-	name = "Escape Pod Five"
-	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/maintenance/seconddeck/foreport)
 "uN" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -31619,7 +31619,7 @@ gH
 Up
 hz
 jk
-jQ
+aF
 kA
 Qe
 Ok
@@ -31631,7 +31631,7 @@ Oj
 Qe
 Qe
 uc
-uL
+bq
 vv
 wl
 Pq

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -213,33 +213,14 @@
 /turf/simulated/floor/wood/walnut,
 /area/medical/descanso)
 "aar" = (
-/obj/machinery/camera/network/security{
-	c_tag = "Security Wing - Locker Room";
-	dir = 8
+/obj/machinery/door/airlock/external/escapepod{
+	icon_state = "closed";
+	id_tag = "escape_pod7_berth_hatch";
+	name = "Escape Pod Seven"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26
-	},
-/obj/machinery/light_switch{
-	pixel_x = 22;
-	pixel_y = -10
-	},
-/obj/item/stack/medical/advanced/bruise_pack,
-/obj/item/stack/medical/advanced/ointment,
-/obj/structure/closet/secure_closet/security_torch,
-/obj/effect/floor_decal/corner/red{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/effect/floor_decal/industrial/outline/yellow{
-	color = "#404040"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/locker)
+/obj/machinery/shield_diffuser,
+/turf/simulated/floor/plating,
+/area/shuttle/pod_airlock/pod7)
 "aas" = (
 /obj/machinery/fabricator,
 /turf/simulated/floor/wood/walnut,
@@ -419,22 +400,14 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/locker)
 "aaF" = (
-/obj/structure/closet/secure_closet/security_torch/cadet,
-/obj/item/stack/medical/advanced/bruise_pack,
-/obj/item/stack/medical/advanced/ointment,
-/obj/effect/floor_decal/corner/red{
-	dir = 6
+/obj/machinery/door/airlock/external/escapepod{
+	icon_state = "closed";
+	id_tag = "escape_pod8_berth_hatch";
+	name = "Escape Pod Eight"
 	},
-/obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/effect/floor_decal/industrial/outline/yellow{
-	color = "#404040"
-	},
-/obj/item/clothing/mask/gas/half,
-/turf/simulated/floor/tiled/dark,
-/area/security/locker)
+/obj/machinery/shield_diffuser,
+/turf/simulated/floor/plating,
+/area/shuttle/pod_airlock/pod8)
 "aaG" = (
 /obj/machinery/vending/snack{
 	dir = 4
@@ -624,21 +597,14 @@
 /turf/simulated/floor/wood/walnut,
 /area/medical/descanso)
 "aaS" = (
-/obj/item/stack/medical/advanced/bruise_pack,
-/obj/item/stack/medical/advanced/ointment,
-/obj/structure/closet/secure_closet/security_torch,
-/obj/effect/floor_decal/corner/red{
-	dir = 6
+/obj/machinery/door/airlock/external/escapepod{
+	icon_state = "closed";
+	id_tag = "escape_pod9_berth_hatch";
+	name = "Escape Pod Nine"
 	},
-/obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/effect/floor_decal/industrial/outline/yellow{
-	color = "#404040"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/locker)
+/obj/machinery/shield_diffuser,
+/turf/simulated/floor/plating,
+/area/shuttle/pod_airlock/pod9)
 "aaT" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/item/device/radio/intercom/department/security{
@@ -769,31 +735,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/brig/perma)
 "abb" = (
-/obj/item/device/radio,
-/obj/item/weapon/crowbar,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+/obj/machinery/door/airlock/external/escapepod{
+	icon_state = "closed";
+	id_tag = "escape_pod10_berth_hatch";
+	name = "Escape Pod Ten"
 	},
-/obj/machinery/light,
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -28
-	},
-/obj/structure/cable/green,
-/obj/structure/closet/secure_closet/brigchief,
-/obj/effect/floor_decal/corner/red{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 6
-	},
-/obj/effect/floor_decal/industrial/outline/yellow{
-	color = "#404040"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/bo)
+/obj/machinery/shield_diffuser,
+/turf/simulated/floor/plating,
+/area/shuttle/pod_airlock/pod10)
 "abc" = (
 /obj/machinery/camera/network/medbay{
 	c_tag = "Infirmary - Emergency Treatment Center Aft";
@@ -1023,6 +972,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/locker)
+"abs" = (
+/obj/machinery/door/airlock/external/escapepod{
+	icon_state = "closed";
+	id_tag = "escape_pod11_berth_hatch";
+	name = "Escape Pod Eleven"
+	},
+/obj/machinery/shield_diffuser,
+/turf/simulated/floor/plating,
+/area/shuttle/pod_airlock/pod11)
 "abt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -3526,33 +3484,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralstarboard)
-"afV" = (
-/obj/machinery/door/airlock/external/escapepod{
-	icon_state = "closed";
-	id_tag = "escape_pod7_berth_hatch";
-	name = "Escape Pod Seven"
-	},
-/obj/machinery/shield_diffuser,
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck/forestarboard)
-"afW" = (
-/obj/machinery/door/airlock/external/escapepod{
-	icon_state = "closed";
-	id_tag = "escape_pod8_berth_hatch";
-	name = "Escape Pod Eight"
-	},
-/obj/machinery/shield_diffuser,
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck/centralstarboard)
-"afX" = (
-/obj/machinery/door/airlock/external/escapepod{
-	icon_state = "closed";
-	id_tag = "escape_pod9_berth_hatch";
-	name = "Escape Pod Nine"
-	},
-/obj/machinery/shield_diffuser,
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck/centralstarboard)
 "afY" = (
 /obj/machinery/camera/network/medbay{
 	c_tag = "Infirmary - Staff Lounge";
@@ -4023,6 +3954,34 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d1starboard)
+"agB" = (
+/obj/machinery/camera/network/security{
+	c_tag = "Security Wing - Locker Room";
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/obj/machinery/light_switch{
+	pixel_x = 22;
+	pixel_y = -10
+	},
+/obj/item/stack/medical/advanced/bruise_pack,
+/obj/item/stack/medical/advanced/ointment,
+/obj/structure/closet/secure_closet/security_torch,
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/red{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/outline/yellow{
+	color = "#404040"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/locker)
 "agD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /obj/structure/railing/mapped{
@@ -4465,6 +4424,42 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/surgery2)
+"aho" = (
+/obj/structure/closet/secure_closet/security_torch/cadet,
+/obj/item/stack/medical/advanced/bruise_pack,
+/obj/item/stack/medical/advanced/ointment,
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/red{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/outline/yellow{
+	color = "#404040"
+	},
+/obj/item/clothing/mask/gas/half,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/locker)
+"ahp" = (
+/obj/item/stack/medical/advanced/bruise_pack,
+/obj/item/stack/medical/advanced/ointment,
+/obj/structure/closet/secure_closet/security_torch,
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/red{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/outline/yellow{
+	color = "#404040"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/locker)
 "ahq" = (
 /turf/simulated/wall/prepainted,
 /area/crew_quarters/courtroom)
@@ -7147,6 +7142,32 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/brig/perma)
+"amf" = (
+/obj/item/device/radio,
+/obj/item/weapon/crowbar,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/machinery/light,
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -28
+	},
+/obj/structure/cable/green,
+/obj/structure/closet/secure_closet/brigchief,
+/obj/effect/floor_decal/corner/red{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/red{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/outline/yellow{
+	color = "#404040"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/bo)
 "amg" = (
 /obj/structure/hygiene/toilet{
 	dir = 1
@@ -15628,24 +15649,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/foreport)
-"aQI" = (
-/obj/machinery/door/airlock/external/escapepod{
-	icon_state = "closed";
-	id_tag = "escape_pod10_berth_hatch";
-	name = "Escape Pod Ten"
-	},
-/obj/machinery/shield_diffuser,
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck/foreport)
-"aQK" = (
-/obj/machinery/door/airlock/external/escapepod{
-	icon_state = "closed";
-	id_tag = "escape_pod11_berth_hatch";
-	name = "Escape Pod Eleven"
-	},
-/obj/machinery/shield_diffuser,
-/turf/simulated/floor/plating,
-/area/maintenance/firstdeck/centralport)
 "aRb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -19206,26 +19209,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/reslab)
-"cWi" = (
-/obj/structure/closet/secure_closet/security_torch/cadet,
-/obj/item/stack/medical/advanced/bruise_pack,
-/obj/item/stack/medical/advanced/ointment,
-/obj/effect/floor_decal/corner/red{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/effect/floor_decal/industrial/outline/yellow{
-	color = "#404040"
-	},
-/obj/item/clothing/mask/gas/half,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/locker)
 "cWR" = (
 /obj/machinery/camera/network/security{
 	c_tag = "Security Wing - Interview Room 1";
@@ -19339,28 +19322,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/lounge)
-"dbM" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/effect/floor_decal/industrial/outline/yellow{
-	color = "#404040"
-	},
-/obj/structure/closet/secure_closet{
-	name = "Secure Evidence Locker";
-	req_access = list("ACCESS_SECURITY")
-	},
-/obj/random/illegal,
-/turf/simulated/floor/tiled/dark,
-/area/security/evidence)
 "dcb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -21772,6 +21733,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/aft)
+"gyi" = (
+/obj/structure/flora/pottedplant/decorative,
+/turf/simulated/floor/tiled/dark,
+/area/security/wing)
 "gyP" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -22303,16 +22268,6 @@
 /obj/effect/floor_decal/corner/paleblue,
 /turf/simulated/floor/tiled/white,
 /area/medical/infirmary)
-"hjc" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/camera/network/security{
-	c_tag = "Seguridad - Campo de tiro";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/shooting)
 "hjq" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
@@ -26865,6 +26820,10 @@
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/security/storage)
+"mfA" = (
+/obj/structure/flora/pottedplant/decorative,
+/turf/simulated/floor/tiled/dark,
+/area/security/brig/psionic)
 "mfH" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical{
@@ -27447,6 +27406,23 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/detectives_office)
+"mKc" = (
+/obj/structure/closet/secure_closet/security_torch/cadet,
+/obj/item/stack/medical/advanced/bruise_pack,
+/obj/item/stack/medical/advanced/ointment,
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/red{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/outline/yellow{
+	color = "#404040"
+	},
+/obj/item/clothing/mask/gas/half,
+/turf/simulated/floor/tiled/dark,
+/area/security/locker)
 "mKw" = (
 /obj/structure/railing/mapped{
 	dir = 8;
@@ -31778,6 +31754,16 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/misc_lab)
+"rxE" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/camera/network/security{
+	c_tag = "Seguridad - Campo de tiro";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/shooting)
 "rxK" = (
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -33052,10 +33038,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftport)
-"sJS" = (
-/obj/structure/flora/pottedplant/decorative,
-/turf/simulated/floor/tiled/dark,
-/area/security/wing)
 "sLb" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -34682,10 +34664,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/aft)
-"vey" = (
-/obj/structure/flora/pottedplant/decorative,
-/turf/simulated/floor/tiled/dark,
-/area/security/brig/psionic)
 "veF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -35354,6 +35332,28 @@
 /obj/item/weapon/storage/firstaid/adv,
 /turf/simulated/floor/tiled,
 /area/assembly/robotics)
+"wvk" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/red{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/outline/yellow{
+	color = "#404040"
+	},
+/obj/structure/closet/secure_closet{
+	name = "Secure Evidence Locker";
+	req_access = list("ACCESS_SECURITY")
+	},
+/obj/random/illegal,
+/turf/simulated/floor/tiled/dark,
+/area/security/evidence)
 "wvY" = (
 /obj/structure/morgue{
 	dir = 8
@@ -43940,8 +43940,8 @@ oDg
 goa
 frA
 rnp
-cWi
-aaF
+aho
+mKc
 dZx
 daB
 bpM
@@ -44152,7 +44152,7 @@ eZX
 nHR
 sOp
 flF
-hjc
+rxE
 uwi
 gGO
 aga
@@ -44545,10 +44545,10 @@ sxT
 oDg
 saS
 njb
-aar
-aaS
-aaS
-aaS
+agB
+ahp
+ahp
+ahp
 aex
 uwi
 adw
@@ -45177,7 +45177,7 @@ anA
 aoF
 nJo
 arj
-sJS
+gyi
 tkr
 tAS
 aaa
@@ -45771,7 +45771,7 @@ cwQ
 nFh
 hDp
 aHY
-abb
+amf
 cHj
 akQ
 amh
@@ -46151,7 +46151,7 @@ qSD
 amb
 ape
 apM
-dbM
+wvk
 qSD
 vMw
 nBD
@@ -49010,7 +49010,7 @@ akq
 amT
 anc
 alU
-vey
+mfA
 arc
 arc
 arr
@@ -52410,7 +52410,7 @@ akb
 bNb
 bQb
 aeT
-afV
+aar
 agS
 ahW
 aji
@@ -52444,7 +52444,7 @@ rAj
 aoP
 ahq
 aPL
-aQI
+abb
 aRC
 bTb
 bWb
@@ -53218,7 +53218,7 @@ anb
 bOb
 bRb
 aeV
-afW
+aaF
 agW
 aia
 aji
@@ -54026,7 +54026,7 @@ aMb
 bPb
 bSb
 aeX
-afX
+aaS
 agY
 ahX
 acD
@@ -54060,7 +54060,7 @@ aoM
 qPH
 ahq
 aPR
-aQK
+abs
 aRG
 bVb
 bYb

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -21733,10 +21733,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/aft)
-"gyi" = (
-/obj/structure/flora/pottedplant/decorative,
-/turf/simulated/floor/tiled/dark,
-/area/security/wing)
 "gyP" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -24473,6 +24469,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/infirmreception)
+"jyY" = (
+/obj/structure/flora/pottedplant/decorative,
+/turf/simulated/floor/tiled/dark,
+/area/security/wing)
 "jzb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -24855,6 +24855,16 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
+"jVi" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/camera/network/security{
+	c_tag = "Seguridad - Campo de tiro";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/shooting)
 "jWb" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/research{
@@ -26720,10 +26730,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralport)
-"mbn" = (
-/obj/structure/sign/warning/pods/south,
-/turf/simulated/wall/r_wall/hull,
-/area/maintenance/firstdeck/forestarboard)
 "mbK" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 8
@@ -26820,10 +26826,6 @@
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/security/storage)
-"mfA" = (
-/obj/structure/flora/pottedplant/decorative,
-/turf/simulated/floor/tiled/dark,
-/area/security/brig/psionic)
 "mfH" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical{
@@ -27406,23 +27408,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/detectives_office)
-"mKc" = (
-/obj/structure/closet/secure_closet/security_torch/cadet,
-/obj/item/stack/medical/advanced/bruise_pack,
-/obj/item/stack/medical/advanced/ointment,
-/obj/effect/floor_decal/corner/red{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/effect/floor_decal/industrial/outline/yellow{
-	color = "#404040"
-	},
-/obj/item/clothing/mask/gas/half,
-/turf/simulated/floor/tiled/dark,
-/area/security/locker)
 "mKw" = (
 /obj/structure/railing/mapped{
 	dir = 8;
@@ -29228,6 +29213,10 @@
 /obj/effect/floor_decal/techfloor,
 /turf/simulated/floor/tiled/steel_grid,
 /area/turbolift/robotics_lift)
+"oMH" = (
+/obj/structure/flora/pottedplant/decorative,
+/turf/simulated/floor/tiled/dark,
+/area/security/brig/psionic)
 "oNm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -31754,16 +31743,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/misc_lab)
-"rxE" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/camera/network/security{
-	c_tag = "Seguridad - Campo de tiro";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/shooting)
 "rxK" = (
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -33790,6 +33769,28 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
+"tvc" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/red{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/outline/yellow{
+	color = "#404040"
+	},
+/obj/structure/closet/secure_closet{
+	name = "Secure Evidence Locker";
+	req_access = list("ACCESS_SECURITY")
+	},
+/obj/random/illegal,
+/turf/simulated/floor/tiled/dark,
+/area/security/evidence)
 "tvu" = (
 /obj/machinery/ai_status_display,
 /turf/simulated/wall/prepainted,
@@ -35332,28 +35333,6 @@
 /obj/item/weapon/storage/firstaid/adv,
 /turf/simulated/floor/tiled,
 /area/assembly/robotics)
-"wvk" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 9
-	},
-/obj/effect/floor_decal/industrial/outline/yellow{
-	color = "#404040"
-	},
-/obj/structure/closet/secure_closet{
-	name = "Secure Evidence Locker";
-	req_access = list("ACCESS_SECURITY")
-	},
-/obj/random/illegal,
-/turf/simulated/floor/tiled/dark,
-/area/security/evidence)
 "wvY" = (
 /obj/structure/morgue{
 	dir = 8
@@ -35376,6 +35355,23 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/storage)
+"wxc" = (
+/obj/structure/closet/secure_closet/security_torch/cadet,
+/obj/item/stack/medical/advanced/bruise_pack,
+/obj/item/stack/medical/advanced/ointment,
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/red{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/outline/yellow{
+	color = "#404040"
+	},
+/obj/item/clothing/mask/gas/half,
+/turf/simulated/floor/tiled/dark,
+/area/security/locker)
 "wyb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43941,7 +43937,7 @@ goa
 frA
 rnp
 aho
-mKc
+wxc
 dZx
 daB
 bpM
@@ -44152,7 +44148,7 @@ eZX
 nHR
 sOp
 flF
-rxE
+jVi
 uwi
 gGO
 aga
@@ -45177,7 +45173,7 @@ anA
 aoF
 nJo
 arj
-gyi
+jyY
 tkr
 tAS
 aaa
@@ -46151,7 +46147,7 @@ qSD
 amb
 ape
 apM
-wvk
+tvc
 qSD
 vMw
 nBD
@@ -49010,7 +49006,7 @@ akq
 amT
 anc
 alU
-mfA
+oMH
 arc
 arc
 arr
@@ -52612,7 +52608,7 @@ act
 act
 act
 aeS
-hBr
+abP
 agT
 ahX
 aji
@@ -52809,12 +52805,12 @@ aaa
 aaa
 aaa
 aaa
-hBr
-hBr
-hBr
-hBr
-hBr
-mbn
+abP
+abP
+abP
+abP
+abP
+xEq
 rhO
 ahY
 aji
@@ -53016,7 +53012,7 @@ acw
 acw
 acw
 aeU
-hBr
+abP
 agV
 bjI
 aji

--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -1783,3 +1783,21 @@
 /area/crew_quarters/courtroom_private
 	name = "\improper Cubierta 1 - Sala de audiencias privada"
 	req_access = list(access_lawyer)
+
+//pods
+/area/shuttle/pod_airlock
+	name = "\improper Pods de escape - Esculsa de aire"
+	requires_power = 0
+	dynamic_lighting = 1
+
+/area/shuttle/pod_airlock/pod1
+/area/shuttle/pod_airlock/pod2
+/area/shuttle/pod_airlock/pod3
+/area/shuttle/pod_airlock/pod4
+/area/shuttle/pod_airlock/pod5
+/area/shuttle/pod_airlock/pod6
+/area/shuttle/pod_airlock/pod7
+/area/shuttle/pod_airlock/pod8
+/area/shuttle/pod_airlock/pod9
+/area/shuttle/pod_airlock/pod10
+/area/shuttle/pod_airlock/pod11


### PR DESCRIPTION
## ¿Qué hace este PR?
Hace que las puertas de los pods no se queden sin energía.

## ¿Por qué es bueno para el juego?
Porque así la gente no se queda atrapada en la nave si no hay energía y están evacuando.

## Changelog
:cl:
**add:** Un área sobre la puerta para que no se quede sin energia.
/:cl: