### PR TITLE
Bolts de Saferoom de Deck 3

### DIFF
--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -4692,6 +4692,7 @@
 "jh" = (
 /obj/machinery/door/airlock/vault/bolted{
 	id_tag = "civsafedoor";
+	locked = 0;
 	name = "Third Deck Safe Room"
 	},
 /obj/machinery/door/firedoor,


### PR DESCRIPTION
## ¿Qué hace este PR?
Hace que la saferoom de la cubierta 3 venga desbolteada por defecto.

## ¿Por qué es bueno para el juego?
Para que la gente que se tiene que ir afk un ratito pueda esconderse ahí sin preocuparse de estar muerto por SM o Radiacion al volver.

## Changelog
:cl:

**del:** Bolts de la saferrom de la cubierta 3
/:cl: