### PR TITLE
Headcrabs como evento

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1796,6 +1796,7 @@
 #include "code\modules\events\event_dynamic.dm"
 #include "code\modules\events\gravity.dm"
 #include "code\modules\events\grid_check.dm"
+#include "code\modules\events\headcrab_infestation.dm"
 #include "code\modules\events\infestation.dm"
 #include "code\modules\events\ion_storm.dm"
 #include "code\modules\events\mail.dm"

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -171,6 +171,7 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Solar Storm",							/datum/event/solar_storm, 				10,		list(ASSIGNMENT_ENGINEER = 20, ASSIGNMENT_SECURITY = 10), 1),
 		new /datum/event_meta/no_overmap(EVENT_LEVEL_MODERATE, "Space Dust",				/datum/event/dust	, 					30, 	list(ASSIGNMENT_ENGINEER = 10)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Spider Infestation",					/datum/event/spider_infestation, 		25,		list(ASSIGNMENT_SECURITY = 15), 1),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Headcrabs Infestation",				/datum/event/headcrab_infestation, 		25,		list(ASSIGNMENT_SECURITY = 25), 1),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Virology Breach",						/datum/event/prison_break/virology,		0,		list(ASSIGNMENT_MEDICAL = 100)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Xenobiology Breach",					/datum/event/prison_break/xenobiology,	0,		list(ASSIGNMENT_SCIENCE = 100)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Toilet Flooding",						/datum/event/toilet_clog/flood,			50, 	list(ASSIGNMENT_JANITOR = 20)),

--- a/code/modules/events/event_dynamic.dm
+++ b/code/modules/events/event_dynamic.dm
@@ -60,6 +60,10 @@ var/list/event_last_fired = list()
 			possibleEvents[/datum/event/spider_infestation] = max(active_with_role["Security"], 5) + 5
 		possibleEvents[/datum/event/random_antag] = max(active_with_role["Security"], 5) + 2.5
 
+	if(active_with_role["Security"] > 0)
+		if(!sent_headcrab_to_station)
+			possibleEvents[/datum/event/headcrab_infestation] = max(active_with_role["Security"], 5) + 5
+
 	for(var/event_type in event_last_fired) if(possibleEvents[event_type])
 		var/time_passed = world.time - event_last_fired[event_type]
 		var/full_recharge_after = 60 * 60 * 10 * 3 // 3 hours

--- a/code/modules/events/headcrab_infestation.dm
+++ b/code/modules/events/headcrab_infestation.dm
@@ -1,0 +1,39 @@
+/var/global/sent_headcrab_to_station = 0
+
+/datum/event/headcrab_infestation
+	announceWhen	= 10
+	var/spawncount = 1
+
+
+/datum/event/headcrab_infestation/setup()
+	announceWhen = rand(announceWhen, announceWhen + 60)
+	spawncount = rand(3 * severity, 6 * severity)
+	sent_headcrab_to_station = 0
+
+/datum/event/headcrab_infestation/announce()
+	GLOB.using_map.unidentified_lifesigns_announcement()
+
+/datum/event/headcrab_infestation/start()
+	var/list/vents = list()
+	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in world)
+		if(!temp_vent.welded && temp_vent.network && temp_vent.loc.z in affecting_z)
+			if(temp_vent.network.normal_members.len > 50)
+				vents += temp_vent
+
+	while((spawncount >= 10) && vents.len)
+		var/obj/vent = pick(vents)
+		new /mob/living/simple_animal/hostile/headcrab(vent.loc)
+		vents -= vent
+		spawncount--
+
+	while((spawncount >= 5) && vents.len)
+		var/obj/vent = pick(vents)
+		new /mob/living/simple_animal/hostile/headcrab/fast(vent.loc)
+		vents -= vent
+		spawncount--
+
+	while((spawncount >= 5) && vents.len)
+		var/obj/vent = pick(vents)
+		new /mob/living/simple_animal/hostile/headcrab/poison(vent.loc)
+		vents -= vent
+		spawncount--


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega evento de Headcrabs. Con un máximo de 10 headcrabs normales, 5 rápidos o 5 poision dispersos por toda la nave.
Talvez haya que checar bien la probabilidad, tiene casi la misma de las arañas.

## ¿Por qué es bueno para el juego?
Agrega esto como evento facilitando para que puedan aparecer sin necesidad de admin o que sea mas fácil para ellos ponerlos.

## Changelog
:cl:
**add:** Evento de Headcrabs
/:cl: