### PR TITLE
Evento de Headcrabs

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1797,6 +1797,7 @@
 #include "code\modules\events\gravity.dm"
 #include "code\modules\events\grid_check.dm"
 #include "code\modules\events\infestation.dm"
+#include "code\modules\events\infestation_headcrabs.dm"
 #include "code\modules\events\ion_storm.dm"
 #include "code\modules\events\mail.dm"
 #include "code\modules\events\maint_drones.dm"

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -174,7 +174,8 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Virology Breach",						/datum/event/prison_break/virology,		0,		list(ASSIGNMENT_MEDICAL = 100)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Xenobiology Breach",					/datum/event/prison_break/xenobiology,	0,		list(ASSIGNMENT_SCIENCE = 100)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Toilet Flooding",						/datum/event/toilet_clog/flood,			50, 	list(ASSIGNMENT_JANITOR = 20)),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Drone Uprising",						/datum/event/rogue_maint_drones/,		25,		list(ASSIGNMENT_ENGINEER = 30))
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Drone Uprising",						/datum/event/rogue_maint_drones/,		25,		list(ASSIGNMENT_ENGINEER = 30)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Infestación de Headcrabs",				/datum/event/infestation_headcrab, 		100,	list(ASSIGNMENT_SECURITY = 50)),
 	)
 
 /datum/event_container/major

--- a/code/modules/events/event_dynamic.dm
+++ b/code/modules/events/event_dynamic.dm
@@ -37,6 +37,7 @@ var/list/event_last_fired = list()
 
 	possibleEvents[/datum/event/rogue_drone] = 5 + 25 * active_with_role["Engineer"] + 25 * active_with_role["Security"]
 	possibleEvents[/datum/event/infestation] = 100 + 100 * active_with_role["Janitor"]
+	possibleEvents[/datum/event/infestation_headcrab] = 50 + 50 * active_with_role["Security"]
 
 	possibleEvents[/datum/event/communications_blackout] = 50 + 25 * active_with_role["AI"] + active_with_role["Scientist"] * 25
 	possibleEvents[/datum/event/ionstorm] = active_with_role["AI"] * 25 + active_with_role["Robot"] * 25 + active_with_role["Engineer"] * 10 + active_with_role["Scientist"] * 5

--- a/code/modules/events/infestation_headcrabs.dm
+++ b/code/modules/events/infestation_headcrabs.dm
@@ -1,0 +1,96 @@
+#define LOC_KITCHEN 0
+#define LOC_ATMOS 1
+#define LOC_INCIN 2
+#define LOC_CHAPEL 3
+#define LOC_LIBRARY 4
+#define LOC_HYDRO 5
+#define LOC_VAULT 6
+#define LOC_CONSTR 7
+#define LOC_TECH 8
+#define LOC_TACTICAL 9
+
+#define VERM_HEADCRAB 0
+#define VERM_HEADCRAB_F 1
+#define VERM_HEADCRAB_P 2
+
+/datum/event/infestation_headcrab
+	announceWhen = 10
+	endWhen = 11
+	var/area/location
+	var/vermin
+	var/vermstring
+
+/datum/event/infestation_headcrab/start()
+	var/list/vermin_turfs
+	var/attempts = 3
+	do
+		vermin_turfs = set_location_get_infestation_turfs()
+		if(!location)
+			return
+	while(!vermin_turfs && --attempts > 0)
+
+	if(!vermin_turfs)
+		log_debug("La infestación de Headcrabs no se pudo realizar después de 3 intentos. Abortando.")
+		kill()
+
+	var/list/spawn_types = list()
+	var/max_number
+	vermin = rand(0,2)
+	switch(vermin)
+		if(VERM_HEADCRAB)
+			spawn_types = list(/mob/living/simple_animal/hostile/headcrab)
+			max_number = 8
+			vermstring = "Headcrabs"
+		if(VERM_HEADCRAB_F)
+			spawn_types = list(/mob/living/simple_animal/hostile/headcrab/fast)
+			max_number = 6
+			vermstring = "Headcrabs rapidos"
+		if(VERM_HEADCRAB_P)
+			spawn_types = list(/mob/living/simple_animal/hostile/headcrab/poison)
+			max_number = 4
+			vermstring = "Headcrabs venenosos"
+
+	spawn(0)
+		var/num = 0
+		for(var/i = 1 to severity)
+			num += rand(2,max_number)
+		log_and_message_admins("Infestación de spawneada ([vermstring] x[num]) en [location]", location = pick_area_turf(location))
+		while(vermin_turfs.len && num > 0)
+			var/turf/simulated/floor/T = pick(vermin_turfs)
+			vermin_turfs.Remove(T)
+			num--
+
+			var/spawn_type = pick(spawn_types)
+			var/obj/effect/spider/spiderling/S = new spawn_type(T)
+			if(istype(S))
+				S.amount_grown = -1
+
+/datum/event/infestation_headcrab/announce()
+	command_announcement.Announce("El bioescaner indica la presencia de formas de vida desconocidas en [location]. Es probable que haya más infestación si no se controla.", "[location_name()] Biologic Sensor Network", zlevels = affecting_z)
+
+/datum/event/infestation_headcrab/proc/set_location_get_infestation_turfs()
+	location = pick_area(list(/proc/is_not_space_area, /proc/is_station_area))
+	if(!location)
+		log_debug("La infestación de Headcrabs no se pudo realizar. Abortando.")
+		kill()
+		return
+
+	var/list/vermin_turfs = get_area_turfs(location, list(/proc/not_turf_contains_dense_objects, /proc/IsTurfAtmosSafe))
+	if(!vermin_turfs.len)
+		log_debug("La infestación de Headcrabs fallo en encontrar un lugar adecuado en [location].")
+		return
+	return vermin_turfs
+
+#undef LOC_KITCHEN
+#undef LOC_ATMOS
+#undef LOC_INCIN
+#undef LOC_CHAPEL
+#undef LOC_LIBRARY
+#undef LOC_HYDRO
+#undef LOC_VAULT
+#undef LOC_TECH
+#undef LOC_TACTICAL
+
+#undef VERM_HEADCRAB
+#undef VERM_HEADCRAB_F
+#undef VERM_HEADCRAB_P

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -36,7 +36,7 @@ exactly 0 "incorrect indentations" '^( {4,})' -P
 exactly 28 "text2path uses" 'text2path'
 exactly 3 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 1 "goto uses" 'goto '
-exactly 501 "spawn uses" 'spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
+exactly 502 "spawn uses" 'spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
 # With the potential exception of << if you increase any of these numbers you're probably doing it wrong
 
 broken_files=0


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega la posibilidad de que se produzca un evento de Headcrabs, dependiendo de la cantidad de Seguridad que haya.
Es igual que las infestaciones de ratones, lagartos y arañas, spawnean cierta cantidad en cierta área de la nave.

## ¿Por qué es bueno para el juego?
Permite colocar un evento para que se le de uso a los Headcrabs, además de facilitar el spawn para los admins.

## Imágenes del cambio
![image](https://user-images.githubusercontent.com/62310132/93840584-48b6ec00-fc67-11ea-8d9a-ba608e7577dd.png)

## Changelog
:cl:
**add:** Evento aleatorio de Headcrabs
/:cl: