### PR TITLE
(Propuestas - Smug) Restricciones del Loadout

### DIFF
--- a/maps/torch/loadout/loadout_head.dm
+++ b/maps/torch/loadout/loadout_head.dm
@@ -2,7 +2,6 @@
 	display_name = "SolGov beret selection"
 	description = "A beret denoting service in an organization within SolGov."
 	path = /obj/item/clothing/head/beret/solgov
-	allowed_branches = SOLGOV_BRANCHES
 
 /datum/gear/head/solberet/New()
 	..()
@@ -26,7 +25,6 @@
 /datum/gear/head/solhat
 	display_name = "sol central government hat"
 	path = /obj/item/clothing/head/soft/solgov
-	allowed_branches = SOLGOV_BRANCHES
 
 /datum/gear/head/fleethat
 	display_name = "fleet hat"
@@ -85,7 +83,6 @@
 	display_name = "SC sections beret selection"
 	description = "A beret denoting service in one of the branches within the NTSC."
 	path = /obj/item/clothing/head/beret/solgov/expedition/branch
-	allowed_branches = NT_BRANCHES
 
 /datum/gear/head/ECberet/New()
 	..()
@@ -98,4 +95,3 @@
 	display_name = "Casco Aviador"
 	path = /obj/item/clothing/mask/pilothelmet
 	slot = slot_wear_mask
-	allowed_branches = NT_BRANCHES

--- a/maps/torch/loadout/loadout_head_boh.dm
+++ b/maps/torch/loadout/loadout_head_boh.dm
@@ -24,7 +24,6 @@
 	display_name = "fleet cap"
 	path = /obj/item/clothing/head/soft/solgov/fleet
 	cost = 0
-	allowed_branches = NT_BRANCHES
 
 /datum/gear/head/corpsecberet
 	display_name = "corporate security beret"

--- a/maps/torch/loadout/loadout_suit.dm
+++ b/maps/torch/loadout/loadout_suit.dm
@@ -120,7 +120,6 @@
 	display_name = "Abrigo de invierno, flota"
 	path = /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet
 	cost = 2
-	allowed_branches = NT_BRANCHES
 	allowed_roles = COMMAND_ROLES
 
 /datum/gear/suit/wintercoat_solgov

--- a/maps/torch/loadout/loadout_uniform_boh.dm
+++ b/maps/torch/loadout/loadout_uniform_boh.dm
@@ -17,12 +17,10 @@
 	display_name = "fleet fatigue"
 	path = /obj/item/clothing/under/solgov/utility/fleet
 	cost = 0
-	allowed_branches = NT_BRANCHES
 
 /datum/gear/uniform/fleet/officer
 	display_name = "fleet officer fatigues"
 	path = /obj/item/clothing/under/solgov/utility/fleet/officer
 	cost = 0
-	allowed_branches = NT_BRANCHES
 	allowed_roles = COMMANDANDOFFICER_ROLES
 


### PR DESCRIPTION
## ¿Qué hace este PR?
Elimina las restricciones del loadout relacionadas con las branch de NT, Sol Gov y Exloration fleet.
Cualquier problema, la neko no se explico bien ni especifico :pensive:

## Imágenes del cambio
![image](https://user-images.githubusercontent.com/62310132/94213630-b94f4a00-fead-11ea-8501-8f7605f7a12b.png)

## Changelog
:cl:
**del:** Restricciones del loadout a NT, Sol Gov y Exploration fleet.
/:cl: