### PR TITLE
(Propuesta - ABA) Accesos del Oficial del Hangar

### DIFF
--- a/maps/torch/job/supply_jobs.dm
+++ b/maps/torch/job/supply_jobs.dm
@@ -30,7 +30,7 @@
 
 	access = list(access_maint_tunnels, access_bridge, access_emergency_storage, access_tech_storage,  access_cargo, access_guppy_helm,
 						access_cargo_bot, access_qm, access_mailsorting, access_solgov_crew, access_expedition_shuttle, access_guppy, access_hangar,
-						access_mining, access_mining_office, access_mining_station, access_commissary, access_eva)
+						access_mining, access_mining_office, access_mining_station, access_commissary, access_eva, access_external_airlocks)
 	minimal_access = list()
 
 	software_on_spawn = list(/datum/computer_file/program/supply,


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega al Oficial de Hangar acceso a los Airlocks que dan al exterior de la nave, para que pueda controlar a las naves que dockean. Es su trabajo pues.

## Imágenes del cambio
![image](https://user-images.githubusercontent.com/62310132/94217112-94f86b00-feb7-11ea-92c3-9bedfae0d4af.png)

## Changelog
:cl:
**add:** Acceso al Oficial del Hangar a los Airlocks que dan al exterior de la nave.
/:cl: