### PR TITLE
The combat tech PR moment

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -413,6 +413,18 @@
 
 	startswith = list(/obj/item/weapon/reagent_containers/hypospray/autoinjector = 7)
 
+/obj/item/weapon/storage/box/autoinjectors/advanced
+	name = "box of advanced injectors"
+	desc = "Contiene diferentes tipos de quimicos avanzados en pequeñas dosis."
+
+	startswith = list(/obj/item/weapon/reagent_containers/hypospray/autoinjector/alkysine = 2,
+					/obj/item/weapon/reagent_containers/hypospray/autoinjector/combatpain = 2,
+					/obj/item/weapon/reagent_containers/hypospray/autoinjector/peridaxon = 2,
+					/obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/bicaridine = 2,
+					/obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/kelotane = 2,
+					/obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/dylovene = 2,
+					/obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/dexalin = 2,)
+
 /obj/item/weapon/storage/box/lights
 	name = "box of replacement bulbs"
 	icon = 'icons/obj/storage.dmi'

--- a/maps/torch/infantry/storage.dm
+++ b/maps/torch/infantry/storage.dm
@@ -39,12 +39,13 @@
 
 /obj/item/gunbox/inftech
 	name = "Kit tecnico"
-	desc = "Una caja segura que contiene un arma secundaria y una primaria."
+	desc = "Una caja segura que contiene todo lo que necesitas."
 
 /obj/item/gunbox/inftech/attack_self(mob/living/user)
 	var/list/options = list()
 //	options["Rocket Launcher"] = list(/obj/item/weapon/gun/launcher/rocket/recoilless/sec,/obj/item/ammo_casing/rocket/rcr,/obj/item/ammo_casing/rocket/rcr,/obj/item/weapon/gun/projectile/pistol/military/sec)
-	options["Medico de combate"] = list(/obj/item/weapon/storage/firstaid/stab,/obj/item/weapon/storage/belt/medical/emt,/obj/item/bodybag/cryobag)
+//Activar cuando quiten estas cosas del locker en el mapa	options["Tecnico de combate"] =list(/obj/item/device/multitool,/obj/item/weapon/storage/belt/utility/full,obj/item/clothing/gloves/insulated,obj/item/weapon/plastique,obj/item/weapon/plastique,obj/item/weapon/plastique,obj/item/weapon/plastique)
+	options["Medico de combate"] = list(/obj/item/weapon/storage/firstaid/adv,/obj/item/weapon/storage/firstaid/combat,/obj/item/device/scanner/health,/obj/item/clothing/glasses/hud/health/sun,/obj/item/weapon/storage/belt/medical/emt,/obj/item/bodybag/cryobag,/obj/item/weapon/storage/box/autoinjectors/advanced)
 	var/choice = input(user,"¿Que tipo de equipamiento?") as null|anything in options
 	if(src && choice)
 		var/list/things_to_spawn = options[choice]

--- a/maps/torch/job/hestia_jobs.dm
+++ b/maps/torch/job/hestia_jobs.dm
@@ -86,7 +86,7 @@
 	department = "el Lider de Escuadron"
 	department = "Infanteria"
 	department_flag = INF
-	total_positions = 2
+	total_positions = 1
 	spawn_positions = 1
 	selection_color = "#557e38"
 	economic_power = 4
@@ -94,17 +94,21 @@
 	skill_points = 24
 	minimum_character_age = list(SPECIES_HUMAN = 22)
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/infantry/combat_tech
-	min_skill = list(	SKILL_CONSTRUCTION = SKILL_ADEPT,
-						SKILL_ELECTRICAL   = SKILL_ADEPT,
+	min_skill = list(	SKILL_CONSTRUCTION = SKILL_BASIC,
+						SKILL_ELECTRICAL   = SKILL_BASIC,
 						SKILL_MEDICAL      = SKILL_BASIC,
+						SKILL_ANATOMY      = SKILL_BASIC,
 						SKILL_COMBAT       = SKILL_ADEPT,
 						SKILL_WEAPONS      = SKILL_ADEPT)
 
 	max_skill = list(	SKILL_COMBAT       = SKILL_MAX,
 						SKILL_WEAPONS      = SKILL_MAX,
 						SKILL_EVA		   = SKILL_MAX,
-						SKILL_CONSTRUCTION = SKILL_MAX,
-						SKILL_ELECTRICAL   = SKILL_MAX)
+						SKILL_CONSTRUCTION = SKILL_EXPERT,
+						SKILL_ELECTRICAL   = SKILL_EXPERT,
+						SKILL_MEDICAL      = SKILL_EXPERT,
+						SKILL_ANATOMY      = SKILL_EXPERT)
+
 
 	allowed_branches = list(/datum/mil_branch/marine_corps)
 	allowed_ranks = list(
@@ -119,12 +123,6 @@
 		"Ingeniero de Combate",
 		"Medico de Combate")
 
-/datum/job/combat_tech/is_position_available()
-	if(..())
-		for(var/mob/M in GLOB.player_list)
-			if(M.client && M.mind && M.mind.assigned_role == "Lider de Escuadron")
-				return TRUE
-	return FALSE
 
 /datum/job/combat_tech/get_description_blurb()
 	return "<span class='warning'>NO eres seguridad. Ignorar esto puede conllevar a un Jobban o algo peor...</span> - Eres el unico Tecnico de Combate en el escuadron. Tu trabajo es proveer tanto tu asistencia militar como demoliciones tacticas, en caso de ser necesarias. Puedes asumir el mando si no hay un Lider de Escuadron presente."


### PR DESCRIPTION

El combat technician ahora puede entrar sin necesidad de un squad leader 
![Screenshot_76](https://user-images.githubusercontent.com/63086609/94972246-3a769480-04df-11eb-9f22-bd4ef26f4961.png)

Se alteraron las skills para dibujar la línea entre ing y med: Mínimo de construcción y ingeniería eléctrica bajado de trained a basic
Mínimo de anatomía subido de unskilled a basic
Máximo de anatomía y medicina subido de trained a experienced 
Máximo de construcción y ingeniería eléctrica bajado de master a experienced
Cambios en el equipment kit del combat medic, el equipment kit del combat tech está mapeado en el locker y se tienen que eliminar los ítems aún para agregarlo al kit 
Se agregó un kit de inyectores avanzados (bicaridine, kelotane, dexalin, dylovene, alkysine, peridaxon y oxycodone, dos de cada uno)
![Screenshot_78](https://user-images.githubusercontent.com/63086609/94972402-8fb2a600-04df-11eb-8675-d5412fe86f3e.png)

![Screenshot_77](https://user-images.githubusercontent.com/63086609/94972257-406c7580-04df-11eb-9561-1e6ca588153f.png)

🆑 
add: kit de injectors avanzado para combat medic
tweak: skills de combat technician
remove: restricción de squad leader para combat technician
/:cl: