### PR TITLE
(Propuesta - Fefe) Holopad en la base comerciante

### DIFF
--- a/maps/torch/z1_admin.dmm
+++ b/maps/torch/z1_admin.dmm
@@ -9126,6 +9126,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/machinery/hologram/holopad/longrange,
 /turf/simulated/floor/tiled,
 /area/merchant_station)
 "aPW" = (


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega un Holopad en el puente de la base de los comerciantes.

## ¿Por qué es bueno para el juego?
Para que el comerciante pueda llamar a su nave si esta ya se fue.

## Imágenes del cambio
![image](https://user-images.githubusercontent.com/62310132/95031119-8ca7e900-068a-11eb-9686-61dbc05e79b7.png)

## Changelog
:cl:
**add:** Holopad en la base comerciante
/:cl: